### PR TITLE
Implemented optimistic locking, command mediator serves retry mechanism

### DIFF
--- a/cart-service/src/main/java/com/sulowskikarol/cartservice/infrastructure/repository/entity/CartEntity.java
+++ b/cart-service/src/main/java/com/sulowskikarol/cartservice/infrastructure/repository/entity/CartEntity.java
@@ -1,6 +1,5 @@
 package com.sulowskikarol.cartservice.infrastructure.repository.entity;
 
-import com.sulowskikarol.cartservice.domain.model.CartItem;
 import com.sulowskikarol.cartservice.domain.model.enums.CartStatus;
 import jakarta.persistence.*;
 import lombok.*;
@@ -23,10 +22,12 @@ public class CartEntity {
     @Column(nullable = false)
     private UUID userId;
 
+    @Setter
     @ElementCollection(fetch = FetchType.EAGER)
     @CollectionTable(name = "cart_items", joinColumns = @JoinColumn(name = "cart_id"))
     private List<CartItemEmbeddable> items = new ArrayList<>();
 
+    @Setter
     @Column(nullable = false)
     @Enumerated(EnumType.STRING)
     private CartStatus status;
@@ -34,6 +35,11 @@ public class CartEntity {
     @Column(nullable = false)
     private LocalDateTime createdAt;
 
+    @Setter
     @Column(nullable = false)
     private LocalDateTime updatedAt;
+
+    @Version
+    private Long version;
+
 }

--- a/cart-service/src/main/java/com/sulowskikarol/cartservice/infrastructure/repository/jpa/CartRepositoryImpl.java
+++ b/cart-service/src/main/java/com/sulowskikarol/cartservice/infrastructure/repository/jpa/CartRepositoryImpl.java
@@ -5,6 +5,7 @@ import com.sulowskikarol.cartservice.domain.model.enums.CartStatus;
 import com.sulowskikarol.cartservice.domain.repository.CartRepository;
 import com.sulowskikarol.cartservice.infrastructure.repository.entity.CartEntity;
 import com.sulowskikarol.cartservice.infrastructure.repository.jpa.mapper.CartJpaMapper;
+import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
@@ -30,9 +31,16 @@ public class CartRepositoryImpl implements CartRepository {
                 .map(cartJpaMapper::toDomain);
     }
 
+    @Transactional
     @Override
     public UUID save(Cart cart) {
-        CartEntity saved = cartJpaRepository.save(cartJpaMapper.toEntity(cart));
-        return saved.getId();
+        Optional<CartEntity> optionalCartEntity = cartJpaRepository.findById(cart.getId());
+
+        CartEntity cartEntity = optionalCartEntity.map(entity -> {
+            cartJpaMapper.updateEntity(entity, cart);
+            return entity;
+        }).orElseGet(() -> cartJpaMapper.toEntity(cart));
+
+        return cartJpaRepository.save(cartEntity).getId();
     }
 }

--- a/cart-service/src/main/java/com/sulowskikarol/cartservice/infrastructure/repository/jpa/mapper/CartJpaMapper.java
+++ b/cart-service/src/main/java/com/sulowskikarol/cartservice/infrastructure/repository/jpa/mapper/CartJpaMapper.java
@@ -5,6 +5,8 @@ import com.sulowskikarol.cartservice.domain.model.CartItem;
 import com.sulowskikarol.cartservice.infrastructure.repository.entity.CartEntity;
 import com.sulowskikarol.cartservice.infrastructure.repository.entity.CartItemEmbeddable;
 import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.MappingTarget;
 
 import java.util.List;
 
@@ -13,7 +15,11 @@ public interface CartJpaMapper {
 
     Cart toDomain(CartEntity cartEntity);
 
+    @Mapping(target = "version", ignore = true)
     CartEntity toEntity(Cart cart);
+
+    @Mapping(target = "version", ignore = true)
+    void updateEntity(@MappingTarget CartEntity cartEntity, Cart cart);
 
     CartItem toDomain(CartItemEmbeddable cartItemEmbeddable);
 


### PR DESCRIPTION
Save method in implementation of domain cart repository interface now tries to update a previously retrieved entity instance instead of saving a new one mapped from the domain model. 

JPA Entity Cart has new field - version.

Mapper got a new method, which updates existing entity instance instead of using constructor.

Command mediator retries every handle operation in case OptimisticLockException happened.